### PR TITLE
Update drepl location to dlang-community

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ a is 23
 ```
 ## References
 
-- https://github.com/MartinNowak/drepl
+- https://github.com/dlang-community/drepl


### PR DESCRIPTION
drepl has a new home: https://github.com/dlang-community/drepl

See also: https://github.com/dlang-community/discussions/issues/17